### PR TITLE
Personal email and mutations

### DIFF
--- a/graphql/resolvers/alumnis.js
+++ b/graphql/resolvers/alumnis.js
@@ -4,7 +4,10 @@ const Alumni = require("../../models/Alumni.js");
 
 require("dotenv").config();
 
-const { validateRegisterAlumniInput } = require("../../util/validators");
+const { 
+  validateRegisterAlumniInput,
+  validateEditAlumniProfileInput,
+} = require("../../util/validators");
 
 const {
   handleInputError,
@@ -117,6 +120,117 @@ module.exports = {
       await newAlumni.save();
 
       return newAlumni;
+    },
+
+    async editAlumniProfile(
+      _,
+      {
+        editAlumniProfileInput: {
+          firstName,
+          lastName,
+          oldEmail,
+          newEmail,
+          undergrad,
+          grad,
+          employer,
+          position,
+          location,
+          linkedin,
+        },
+      }
+    ) {
+      const { errors, valid } = validateEditAlumniProfileInput(
+          firstName,
+          lastName,
+          oldEmail,
+          newEmail,
+          undergrad,
+          grad,
+          employer,
+          position,
+          location,
+          linkedin,
+      );
+
+      var coordinates = {
+        latitude: 0,
+        longitude: 0
+      };
+
+      if (!valid) {
+        handleInputError(errors);
+      }
+
+      grad.year = grad.year === "" ? 0 : grad.year;
+      var email = oldEmail;
+
+      if(newEmail !== oldEmail && newEmail !== ""){
+        const isEmailDuplicate = await Alumni.findOne({ email: newEmail });
+        if (isEmailDuplicate) {
+          errors.general = "that new email already exists.";
+          handleInputError(errors);
+        }
+        email = newEmail;
+      }
+
+      const alumniLocation =
+        location.city +
+        ", " +
+        (location.state ? location.state + ", " : "") +
+        location.country;
+
+      var ngcOptions = {
+        provider: "mapquest",
+        httpAdapter: "https",
+        apiKey: process.env.MQ_KEY,
+        formatter: null,
+      };
+
+      var geocoder = nodegeocoder(ngcOptions);
+
+      await geocoder
+        .geocode(alumniLocation)
+        .then(function (res) {
+          var north = Math.random() * 0.007;
+          var south = -1 * Math.random() * 0.007;
+          var east = Math.random() * 0.007;
+          var west = -1 * Math.random() * 0.007;
+          coordinates.latitude = res[0].latitude + north + south;
+          coordinates.longitude = res[0].longitude + east + west;
+        })
+        .catch(function (err) {
+          errors.general =
+            "Invalid location, please check city, state and/or country.";
+          handleInputError(errors);
+        });
+
+      const alumni = await Alumni.findOne({ email: oldEmail });
+
+      if (alumni) {
+        const updatedAlumni = await Alumni.findOneAndUpdate(
+          { email: oldEmail },
+          {
+            firstName,
+            lastName,
+            email,
+            undergrad,
+            grad,
+            employer,
+            position,
+            location,
+            coordinates,
+            linkedin,
+          },
+          {
+            new: true,
+            useFindAndModify: false,
+          }
+        );
+
+        return updatedAlumni;
+      } else {
+        throw new Error("Alumni not found.");
+      }
     },
   },
 };

--- a/graphql/resolvers/users.js
+++ b/graphql/resolvers/users.js
@@ -91,6 +91,7 @@ module.exports = {
             username: user.username,
             photo: user.photo,
             email: user.email,
+            personalEmail: user.personalEmail,
             major: user.major,
             year: user.year,
             graduating: user.graduating,
@@ -323,6 +324,7 @@ module.exports = {
           sex,
           username,
           email,
+          personalEmail,
           password,
           confirmPassword,
           listServ,
@@ -332,6 +334,7 @@ module.exports = {
       firstName = firstName.trim();
       lastName = lastName.trim();
       email = email.toLowerCase();
+      personalEmail = personalEmail.toLowerCase();
       username = username.toLowerCase();
 
       const { valid, errors } = validateRegisterInput(
@@ -345,6 +348,7 @@ module.exports = {
         sex,
         username,
         email,
+        personalEmail,
         password,
         confirmPassword
       );
@@ -384,6 +388,7 @@ module.exports = {
         ethnicity,
         sex,
         username,
+        personalEmail,
         email,
         password,
         createdAt: new Date().toISOString(),
@@ -503,6 +508,7 @@ module.exports = {
           lastName: user.lastName,
           username: user.username,
           email: user.email,
+          personalEmail: user.personalEmail,
           major: user.major,
           year: user.year,
           graduating: user.graduating,
@@ -729,6 +735,7 @@ module.exports = {
         lastName: user.lastName,
         username: user.username,
         email: user.email,
+        personalEmail: user.personalEmail,
         major: user.major,
         year: user.year,
         graduating: user.graduating,
@@ -912,6 +919,7 @@ module.exports = {
       {
         editUserProfileInput: {
           email,
+          personalEmail,
           firstName,
           lastName,
           photo,
@@ -928,6 +936,7 @@ module.exports = {
       }
     ) {
       const { errors, valid } = validateEditUserProfile(
+        personalEmail,
         firstName,
         lastName,
         photo,
@@ -956,6 +965,7 @@ module.exports = {
         const updatedUser = await User.findOneAndUpdate(
           { email },
           {
+            personalEmail,
             firstName,
             lastName,
             photo,
@@ -1086,6 +1096,26 @@ module.exports = {
             useFindAndModify: false,
           }
         );
+      });
+      return users;
+    },
+
+    async insertPersEmailProp() {
+      var users = await User.find();
+      users.forEach(async function(user){
+        const email = user.email;
+        if(!user.personalEmail){
+          const updatedUser = await User.findOneAndUpdate(
+            { email },
+            {
+              personalEmail: "",
+            },
+            {
+              new: true,
+              useFindAndModify: false,
+            },
+          );
+        }
       });
       return users;
     },

--- a/graphql/typeDefs.js
+++ b/graphql/typeDefs.js
@@ -16,6 +16,7 @@ module.exports = gql`
     sex: String!
     username: String!
     email: String!
+    personalEmail: String!
     password: String!
     createdAt: String!
     updatedAt: String!
@@ -210,6 +211,7 @@ module.exports = gql`
     sex: String!
     username: String!
     email: String!
+    personalEmail: String!
     password: String!
     confirmPassword: String!
     listServ: String!
@@ -335,8 +337,22 @@ module.exports = gql`
     linkedin: String!
   }
 
+  input EditAlumniProfileInput {
+    firstName: String!
+    lastName: String!
+    oldEmail: String!
+    newEmail: String!
+    undergrad: UndergradInput!
+    grad: GradInput!
+    employer: String!
+    position: String!
+    location: LocationInput!
+    linkedin: String!
+  }
+
   input EditUserProfileInput {
     email: String!
+    personalEmail: String!
     firstName: String!
     lastName: String!
     photo: String!
@@ -453,6 +469,7 @@ module.exports = gql`
     bookmark(company: String!, username: String!): User!
     deleteBookmark(company: String!, username: String!): User!
     registerAlumni(registerAlumniInput: RegisterAlumniInput): Alumni!
+    editAlumniProfile(editAlumniProfileInput: EditAlumniProfileInput): Alumni!
     changePermission(
       email: String!
       currentEmail: String!
@@ -460,6 +477,7 @@ module.exports = gql`
     ): User!
     editUserProfile(editUserProfileInput: EditUserProfileInput): User!
     editUpdatedAt(editUpdatedAtInput: EditUpdatedAtInput): User!
+    insertPersEmailProp: [User]
     updateYears: [User]
     reimbursementRequest(reimbursementInput: ReimbursementInput): Reimbursement!
     resolveReimbursement(id: ID!, email: String!): Reimbursement!

--- a/models/User.js
+++ b/models/User.js
@@ -51,6 +51,12 @@ const userSchema = new Schema({
     lowercase: true,
     unique: true,
   },
+  personalEmail: {
+    type: String,
+    required: true,
+    lowercase: true,
+    unique: true,
+  },
   password: {
     type: String,
     required: true,

--- a/util/validators.js
+++ b/util/validators.js
@@ -11,6 +11,7 @@ module.exports.validateRegisterInput = (
   sex,
   username,
   email,
+  personalEmail,
   password,
   confirmPassword
 ) => {
@@ -88,6 +89,14 @@ module.exports.validateRegisterInput = (
           "University of Florida or Santa Fe College email required.";
       }
     }
+  }
+
+  if (personalEmail.trim() === "") {
+    errors.personalEmail = "Personal email is required.";
+  } else {
+    if (!personalEmail.match(emailRegex)) {
+      errors.personalEmail = "Invalid personal email address.";
+    } 
   }
 
   if (password === "") {
@@ -369,6 +378,7 @@ module.exports.validateCreateEditCorporationInput = (
 };
 
 module.exports.validateEditUserProfile = (
+  personalEmail,
   firstName,
   lastName,
   photo,
@@ -382,6 +392,15 @@ module.exports.validateEditUserProfile = (
   const errors = {};
 
   const nameValidator = /^[a-zA-Z ',.-]{3,20}$/;
+  const emailRegex = /^([0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*@([0-9a-zA-Z][-\w]*[0-9a-zA-Z]\.)+[a-zA-Z]{2,12})$/;
+
+  if (personalEmail.trim() === "") {
+    errors.personalEmail = "Personal email is required.";
+  } else {
+    if (!personalEmail.match(emailRegex)) {
+      errors.personalEmail = "Invalid personal email address.";
+    } 
+  }
 
   if (firstName.trim() === "") {
     errors.firstName = "First name is required.";
@@ -500,6 +519,132 @@ module.exports.validateRegisterAlumniInput = (
       errors.email = "Invalid email address.";
     }
   }
+
+  if (undergrad.university.trim() === "") {
+    errors.undergradUniversity = "Undergraduate university is required.";
+  }
+
+  if (undergrad.year.trim() === "") {
+    errors.undergradYear = "Undergraduate year is required.";
+  } else {
+    if (!undergrad.year.match(yearValidator)) {
+      errors.undergradYear = "Invalid undergraduate year.";
+    }
+  }
+
+  if (undergrad.major.trim() === "") {
+    errors.undergradMajor = "Undergraduate major is required.";
+  }
+
+  if (
+    grad.university.trim() !== "" ||
+    grad.year.trim() !== "" ||
+    grad.major.trim() !== ""
+  ) {
+    if (grad.university.trim() === "") {
+      errors.gradUniversity = "Graduate university is required.";
+    }
+
+    if (grad.year.trim() === "") {
+      errors.gradYear = "Graduate year is required.";
+    } else {
+      if (!grad.year.match(yearValidator)) {
+        errors.gradYear = "Invalid graduate year.";
+      }
+    }
+
+    if (grad.major.trim() === "") {
+      errors.gradMajor = "Graduate major is required.";
+    }
+  }
+
+  if (
+    grad.university.trim() === "" &&
+    grad.year.trim() === "" &&
+    grad.major.trim() === ""
+  ) {
+    if (employer.trim() === "") {
+      errors.employer = "Employer is required.";
+    }
+
+    if (position.trim() === "") {
+      errors.position = "Position is required.";
+    }
+  }
+
+  if (location.city.trim() === "") {
+    errors.locationCity = "City is required.";
+  }
+
+  if (location.country === "United States") {
+    if (location.state.trim() === "") {
+      errors.locationState = "State is required.";
+    }
+  }
+
+  if (location.country.trim() === "") {
+    errors.locationCountry = "Country is required.";
+  }
+
+  if (linkedin.trim() === "") {
+    errors.linkedin = "LinkedIn Profile link is required.";
+  }
+
+  return {
+    errors,
+    valid: Object.keys(errors).length < 1,
+  };
+};
+
+module.exports.validateEditAlumniProfileInput = (
+  firstName,
+  lastName,
+  oldEmail,
+  newEmail,
+  undergrad,
+  grad,
+  employer,
+  position,
+  location,
+  linkedin
+) => {
+  const errors = {};
+
+  const nameValidator = /^[a-zA-Z ',.-]{3,20}$/;
+  const emailValidator = /^([0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*@([0-9a-zA-Z][-\w]*[0-9a-zA-Z]\.)+[a-zA-Z]{2,12})$/;
+  const yearValidator = /^\d{4}$/;
+
+  if (firstName.trim() === "") {
+    errors.firstName = "First name is required.";
+  } else {
+    if (!firstName.match(nameValidator)) {
+      errors.firstName =
+        "First Name must be at least 3 characters, max 20. No special characters or numbers.";
+    }
+  }
+
+  if (lastName.trim() === "") {
+    errors.lastName = "Last Name is required.";
+  } else {
+    if (!lastName.match(nameValidator)) {
+      errors.lastName =
+        "Last name must be at least 3 characters, max 20. No special characters or numbers.";
+    }
+  }
+
+  if (oldEmail.trim() === "") {
+    errors.email = "Old email is required.";
+  } else {
+    if (!oldEmail.match(emailValidator)) {
+      errors.email = "Invalid old email address.";
+    }
+  }
+
+  if (newEmail.trim() !== "") {
+    if (!newEmail.match(emailValidator)) {
+      errors.email = "Invalid new email address.";
+    }
+  } 
 
   if (undergrad.university.trim() === "") {
     errors.undergradUniversity = "Undergraduate university is required.";


### PR DESCRIPTION
### Summary

Implements personal email as a new, required user property upon registration and profile edits. Validators ensure that it can be any valid email, not necessarily a UF/SF email. A one-time-use mutation "insertPersEmailProp" gives old accounts an empty personalEmail to eliminate potential query errors. "editAlumniProfile" is a mutation make it possible to edit previously immutable alumni profile details, including email.

### Reference

_Reference your Asana task here as shown below_

[Asana link](https://app.asana.com/0/1202843173947642/1203092494154883/f)

### Extra

_please add me (@yairtemkin) as a reviewer. thank u_
