### PR TITLE
dynamic http address server running at message instead hardcoded

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,10 @@ startApolloServer = async () => {
     expressMiddleware(server)
   );
   await new Promise((resolve) => httpServer.listen({ port }, resolve));
-  console.log(`SERVER RUNNING AT http://localhost:5000/`);
+  const addr = httpServer.address();
+  const host = addr.address === '::' ? 'localhost' : addr.address;
+  const hport = addr.port;
+  console.log(`SERVER RUNNING AT http://${host}:${hport}/`);
 };
 
 mongoose


### PR DESCRIPTION
…ard coded

### Summary

previously the console message indicating the address the server was running at was hard coded. So changes to the .env (say the port you were running on) were not being reflected in the log msg.

### Reference

n/a

### Extra

_please add me (@w-omar) as a reviewer. thank u_
